### PR TITLE
Add Registration Logic to CredentialsManager and Registration layout

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.MyApplication"
         tools:targetApi="31">
+
         <activity
             android:name=".EmptyActivity"
             android:exported="false">
@@ -19,15 +20,21 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
+
         <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".RegistrationActivity"
+            android:exported="true">
+        </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/myapplication/CredentialsManager.kt
+++ b/app/src/main/java/com/example/myapplication/CredentialsManager.kt
@@ -3,11 +3,29 @@ package com.example.myapplication
 import android.util.Patterns
 
 class CredentialsManager {
-    val credentials = mutableMapOf<String, String>(
-        //
-    )
+    private val credentials = mutableMapOf<String, String>()
 
-    fun isEmailValid(mail: String): Boolean {
+
+    fun register(email: String, password: String): Pair<Boolean, String> {
+        if (!isEmailValid(email)) {
+            return false to "Invalid email format"
+        }
+
+        if (!isPasswordValid(password)) {
+            return false to "Password must contain at least 8 characters, including uppercase, lowercase, number, and special character"
+        }
+
+        val normalizedEmail = email.lowercase()
+
+        if (credentials.containsKey(normalizedEmail)) {
+            return false to "Email is already registered"
+        }
+
+        credentials[normalizedEmail] = password
+        return true to "Registration successful"
+    }
+
+    fun isEmailValid(email: String): Boolean {
         val pattern = (
                 "[a-zA-Z0-9\\+\\.\\_\\%\\-\\+]{1,256}" +
                         "\\@" +
@@ -16,9 +34,9 @@ class CredentialsManager {
                         "\\." +
                         "[a-zA-Z0-9][a-zA-Z0-9\\-]{0,25}" +
                         ")+"
-                );
+                )
         val regex = Regex(pattern)
-        return regex.matches(mail)
+        return regex.matches(email)
     }
 
     fun isPasswordValid(password: String): Boolean {

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -22,6 +22,8 @@ class MainActivity : AppCompatActivity() {
         get() = findViewById(R.id.passwordEditText)
     private val nextButton: MaterialButton
         get() = findViewById(R.id.buttonNext)
+    private val registerText: MaterialButton
+        get() = findViewById(R.id.buttonRegister)
 
     private val credentialsManager = CredentialsManager()
 
@@ -29,6 +31,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
+
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
@@ -52,7 +55,16 @@ class MainActivity : AppCompatActivity() {
             ) { credentialsManager.isPasswordValid(it) }
 
             if (isEmailValid && isPasswordValid) {
+                val intent = Intent(this, EmptyActivity::class.java)
+                startActivity(intent)
+                finish()
             }
+        }
+
+        // Navigate to RegistrationActivity when "Register now" is clicked
+        registerText.setOnClickListener {
+            val intent = Intent(this, RegistrationActivity::class.java)
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/example/myapplication/RegistrationActivity.kt
+++ b/app/src/main/java/com/example/myapplication/RegistrationActivity.kt
@@ -1,0 +1,86 @@
+package com.example.myapplication
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
+class RegistrationActivity : AppCompatActivity() {
+
+    private val emailLayout: TextInputLayout
+        get() = findViewById(R.id.emailInputLayout)
+    private val emailEditText: TextInputEditText
+        get() = findViewById(R.id.emailEditText)
+    private val passwordLayout: TextInputLayout
+        get() = findViewById(R.id.passwordInputLayout)
+    private val passwordEditText: TextInputEditText
+        get() = findViewById(R.id.passwordEditText)
+    private val registerButton: MaterialButton
+        get() = findViewById(R.id.buttonNext)
+
+    private val credentialsManager = CredentialsManager()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_register)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
+        registerButton.setOnClickListener {
+            val email = emailEditText.text.toString()
+            val password = passwordEditText.text.toString()
+
+            val isEmailValid = validateField(
+                layout = emailLayout,
+                value = email,
+                errorMessage = "Invalid email format"
+            ) { credentialsManager.isEmailValid(it) }
+
+            val isPasswordValid = validateField(
+                layout = passwordLayout,
+                value = password,
+                errorMessage = "Password must contain at least 8 characters, including uppercase, lowercase, number and special character"
+            ) { credentialsManager.isPasswordValid(it) }
+
+            if (isEmailValid && isPasswordValid) {
+                val (success, message) = credentialsManager.register(email, password)
+
+                if (success) {
+                    // Redirect to LoginActivity
+                    val intent = Intent(this, MainActivity::class.java)
+                    startActivity(intent)
+                    finish()
+                } else {
+                    emailLayout.error = message
+                    emailLayout.isErrorEnabled = true
+                }
+            }
+        }
+    }
+
+    private fun validateField(
+        layout: TextInputLayout,
+        value: String,
+        errorMessage: String,
+        validationLogic: (String) -> Boolean
+    ): Boolean {
+        return if (!validationLogic(value)) {
+            layout.error = errorMessage
+            layout.isErrorEnabled = true
+            false
+        } else {
+            layout.isErrorEnabled = false
+            layout.error = null
+            true
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_success.xml
+++ b/app/src/main/res/drawable/ic_success.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M2,20h20"
+        android:strokeWidth="2"
+        android:strokeAlpha="0.3"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="m9,10 l2,2 4,-4"
+        android:strokeWidth="2"
+        android:strokeAlpha="0.3"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M5,4L19,4A2,2 0,0 1,21 6L21,14A2,2 0,0 1,19 16L5,16A2,2 0,0 1,3 14L3,6A2,2 0,0 1,5 4z"
+        android:strokeWidth="2"
+        android:strokeAlpha="0.3"
+        android:strokeColor="#000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round" />
+</vector>

--- a/app/src/main/res/layout/activity_empty.xml
+++ b/app/src/main/res/layout/activity_empty.xml
@@ -6,4 +6,40 @@
     android:layout_height="match_parent"
     tools:context=".EmptyActivity">
 
+    <!-- Success Icon -->
+    <ImageView
+        android:id="@+id/successIcon"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:contentDescription="Success"
+        android:src="@drawable/ic_success"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.2" />
+
+    <!-- Success Message -->
+    <TextView
+        android:id="@+id/successMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="You are logged in!"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/successIcon"
+        app:layout_constraintVertical_bias="0.1" />
+
+    <!-- Continue Button -->
+    <Button
+        android:id="@+id/continueButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Continue"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/successMessage"
+        app:layout_constraintVertical_bias="0.1" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -44,13 +44,22 @@
             android:text="New Member?"
             android:textSize="13sp" />
 
-        <TextView
-            android:id="@+id/textRegister"
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonRegister"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:backgroundTint="@android:color/transparent"
             android:text="Register now"
             android:textColor="@android:color/holo_purple"
-            android:textSize="13sp" />
+            android:textSize="13sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:ignore="ClickableViewAccessibility" />
+
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -108,7 +108,7 @@
         </com.google.android.material.textfield.TextInputLayout>
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/editTextEmail"
+            android:id="@+id/emailInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="Email"

--- a/app/src/test/java/com/example/myapplication/CredentialsManagerTest.kt
+++ b/app/src/test/java/com/example/myapplication/CredentialsManagerTest.kt
@@ -54,7 +54,10 @@ class CredentialsManagerTest {
             "noSpecial"
         )
         passwords.forEach { password ->
-            assertFalse("Failed for password: $password", credentialsManager.isPasswordValid(password))
+            assertFalse(
+                "Failed for password: $password",
+                credentialsManager.isPasswordValid(password)
+            )
         }
     }
 
@@ -65,7 +68,10 @@ class CredentialsManagerTest {
             "NoSpecialChars123"
         )
         passwords.forEach { password ->
-            assertFalse("Failed for password: $password", credentialsManager.isPasswordValid(password))
+            assertFalse(
+                "Failed for password: $password",
+                credentialsManager.isPasswordValid(password)
+            )
         }
     }
 
@@ -76,7 +82,10 @@ class CredentialsManagerTest {
             "NoNumbersHere!"
         )
         passwords.forEach { password ->
-            assertFalse("Failed for password: $password", credentialsManager.isPasswordValid(password))
+            assertFalse(
+                "Failed for password: $password",
+                credentialsManager.isPasswordValid(password)
+            )
         }
     }
 
@@ -89,7 +98,54 @@ class CredentialsManagerTest {
             "C!omplextest789"
         )
         passwords.forEach { password ->
-            assertTrue("Failed for password: $password", credentialsManager.isPasswordValid(password))
+            assertTrue(
+                "Failed for password: $password",
+                credentialsManager.isPasswordValid(password)
+            )
         }
+    }
+
+    @Test
+    fun givenNewValidEmailAndPassword_thenRegisterSuccessfully() {
+        val email = "test@example.com"
+        val password = "Strong@Pass123"
+
+        val (success, message) = credentialsManager.register(email, password)
+        assertTrue("Registration failed for valid credentials: $message", success)
+    }
+
+    @Test
+    fun givenDuplicateEmail_thenReturnError() {
+        val email = "test@example.com"
+        val password = "Strong@Pass123"
+
+        credentialsManager.register(email, password)
+        val (success, message) = credentialsManager.register(email.uppercase(), password)
+
+        assertFalse("Duplicate email registration succeeded unexpectedly", success)
+        assertEquals("Email is already registered", message)
+    }
+
+    @Test
+    fun givenInvalidEmail_thenReturnError() {
+        val email = "invalid_email"
+        val password = "Strong@Pass123"
+
+        val (success, message) = credentialsManager.register(email, password)
+        assertFalse("Invalid email registration succeeded unexpectedly", success)
+        assertEquals("Invalid email format", message)
+    }
+
+    @Test
+    fun givenInvalidPassword_thenReturnError() {
+        val email = "test@example.com"
+        val password = "weak"
+
+        val (success, message) = credentialsManager.register(email, password)
+        assertFalse("Invalid password registration succeeded unexpectedly", success)
+        assertEquals(
+            "Password must contain at least 8 characters, including uppercase, lowercase, number, and special character",
+            message
+        )
     }
 }


### PR DESCRIPTION
This PR adds a register method to the CredentialsManager that:

- Registers a new account if the email is not already in use (case-insensitive).
- Returns an error if the email is already registered.
- Uses a Map for storing email-password pairs, normalizing emails to lowercase for comparison.

Testing

- Verified that duplicate emails (e.g., test@te.st and TEST@te.st) are rejected.
- Confirmed successful registration for unique emails.